### PR TITLE
Add symlink functionality

### DIFF
--- a/src/netstorage.js
+++ b/src/netstorage.js
@@ -340,7 +340,7 @@ class NetStorage {
             return new Promise ((resolve, reject) => {
                 let path=this.buildPath([options.cpcode, options.file])
                 console.info("Creating Symlink for " + path)
-                let newpath = this.buildPath([options.cpcode, options.location])
+                let newpath = this.buildPath([options.cpcode, options.target])
 
                 let request = {
                     method:"POST",

--- a/src/netstorage.js
+++ b/src/netstorage.js
@@ -333,7 +333,33 @@ class NetStorage {
         })
     }
 
+    symlink(options) {
+        return this.parseFileCpCode(options)
+        .then(options => {
+        
+            return new Promise ((resolve, reject) => {
+                let path=this.buildPath([options.cpcode, options.file])
+                console.info("Creating Symlink for " + path)
+                let newpath = this.buildPath([options.cpcode, options.location])
 
+                let request = {
+                    method:"POST",
+                    action: "version=1&action=symlink&target=" + newpath,
+                    path: path,
+                    body: ""
+                }
+                resolve(request)
+            })
+            .then(request => {
+                console.log(request);
+                return this.makeRequest(request)
+            })
+            .then(response => {
+                console.log(response.body)
+                Promise.resolve(response.body)
+            })
+        })
+    }
 
 
     mkdir(options) {


### PR DESCRIPTION
Symlink creation was listed in help but not implemented. I have "translated" the rename() function into the symlink creation, using the API as it is used in the Python NetStorage CMS library.

Behavior and parameter order "path" and "target" is ambiguous, and I think it does not follow "ln -s" order...