### PR TITLE
Update untildify to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "request": "^2.74.0",
     "safe-buffer": "^5.1.1",
     "sywac": "^1.2.0",
-    "untildify": "*"
+    "untildify": "^4.0.0"
   }
 }


### PR DESCRIPTION
because untildify has a breaking change in the new update https://github.com/sindresorhus/untildify/releases/tag/v5.0.0 set the untildify version to 4.0.0.